### PR TITLE
Changes the way that we get the filename to fix an issue in Windows

### DIFF
--- a/src/main/java/com/github/sitture/env/config/ConfigLoader.java
+++ b/src/main/java/com/github/sitture/env/config/ConfigLoader.java
@@ -55,8 +55,7 @@ class ConfigLoader {
 	}
 
 	private String getConfigKeePassFilename() {
-		final String[] buildDir = BuildDirUtils.getBuildDir().split(File.separator);
-		final String defaultFileName = buildDir[buildDir.length-1];
+		final String defaultFileName = new File(BuildDirUtils.getBuildDir()).getName();
 		return PropertyUtils.getProperty(CONFIG_KEEPASS_FILENAME_KEY, defaultFileName);
 	}
 


### PR DESCRIPTION
## Summary
This fixes an issue on windows using File.separator to get the filename

https://stackoverflow.com/questions/10336293/splitting-filenames-using-system-file-separator-symbol

The change is covered by existing tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change or adding to the documentation.
- [ ] I have updated the documentation accordingly.
