### PR TITLE
Editing method to allow for multiple secret paths

### DIFF
--- a/src/test/java/com/github/sitture/envconfig/VaultConfigurationTest.java
+++ b/src/test/java/com/github/sitture/envconfig/VaultConfigurationTest.java
@@ -26,6 +26,17 @@ import static com.github.valfirst.slf4jtest.Assertions.assertThat;
 class VaultConfigurationTest {
 
     @Test
+    void testCanGetConfigurationMapWithMultiplePaths() {
+        stubSelfLookupSuccess();
+        stubReadSecretSuccessForPath("project1/", "key1", "value1");
+        stubReadSecretSuccessForPath("project2/", "key2", "value2");
+        final EnvConfigVaultProperties vaultProperties = getMockVaultProperties("path/to/project1,path/to/project2");
+        final Configuration configuration = new VaultConfiguration(vaultProperties).getConfiguration("default");
+        Assertions.assertEquals("value1", configuration.getString("key1"));
+        Assertions.assertEquals("value2", configuration.getString("key2"));
+        }
+
+    @Test
     void testCanGetConfigurationMapWithData() {
         stubSelfLookupSuccess();
         final String secretPath = "path/to/project/";
@@ -119,5 +130,15 @@ class VaultConfigurationTest {
                 + "    ]\n"
                 + "  }\n"
                 + "}")));
+    }
+
+    private void stubReadSecretSuccessForPath(final String secretPath, final String key, final String value) {
+        stubFor(get("/v1/path/data/to/" + secretPath + "default").willReturn(okJson("{\n"
+                + "  \"data\": {\n"
+                + "    \"data\": {\n"
+                + "       \"" + key + "\": \"" + value + "\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}\n")));
     }
 }


### PR DESCRIPTION
# Summary

We now use long lived JWTs that are published to vault and rotated periodically. The are published in a common area that needs to be accessed at runtime during the tests. We also still need to access the vault spaces for the specific service, so this change allows for a comma separated list of vault secret paths (Eg: dev/qa/service1,dev/qa/common)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [ ] My change requires a change or adding to the documentation.
- [ ] I have updated the documentation accordingly.
